### PR TITLE
Perf/cql identifier dynamicvalues

### DIFF
--- a/input/cql/IMMZD18SBCGLogic.cql
+++ b/input/cql/IMMZD18SBCGLogic.cql
@@ -108,3 +108,11 @@ define "Test Validation":
       and "One BCG dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SCholeraWCRBSVaccine2DosesLogic.cql
+++ b/input/cql/IMMZD18SCholeraWCRBSVaccine2DosesLogic.cql
@@ -229,3 +229,11 @@ define "Test Validation":
     when Patient.id = 'Cholera49.4' then "Cholera dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SCholeraWCRBSVaccine3DosesLogic.cql
+++ b/input/cql/IMMZD18SCholeraWCRBSVaccine3DosesLogic.cql
@@ -289,3 +289,11 @@ define "Test Validation":
     when Patient.id = 'Cholera34.4' then "Cholera dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SCholeraWCVaccinesLogic.cql
+++ b/input/cql/IMMZD18SCholeraWCVaccinesLogic.cql
@@ -272,3 +272,11 @@ define "Test Validation":
     when Patient.id = 'Cholera17.4' then "Cholera booster dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SDTPDelayedOrInterruptedSeriesLogic.cql
+++ b/input/cql/IMMZD18SDTPDelayedOrInterruptedSeriesLogic.cql
@@ -410,3 +410,11 @@ define "Test Validation":
     when Patient.id = 'DTP46.2' then "Pertussis-containing booster dose was administered. Pertussis immunization schedule has been completed" and "Tetanus and diphtheria-containing vaccine booster dose 1 (delayed start)"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SDTPOnTimeStartLogic.cql
+++ b/input/cql/IMMZD18SDTPOnTimeStartLogic.cql
@@ -465,3 +465,11 @@ define "Test Validation":
     when Patient.id = 'DTP25.2' then "Pertussis-containing booster dose was administered. Pertussis immunization schedule has been completed" and "Tetanus and diphtheria-containing vaccine booster dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SDTPPregnancyStartingWith3DosesLogic.cql
+++ b/input/cql/IMMZD18SDTPPregnancyStartingWith3DosesLogic.cql
@@ -218,3 +218,11 @@ define "Test Validation":
     when Patient.id = 'DTP71.2' then "Third tetanus and diphtheria-containing booster dose was administered. Tetanus and diphtheria immunization schedule has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SDTPPregnancyStartingWith4DosesLogic.cql
+++ b/input/cql/IMMZD18SDTPPregnancyStartingWith4DosesLogic.cql
@@ -155,3 +155,11 @@ define "Test Validation":
     when Patient.id = 'DTP82.2' then "Third tetanus and diphtheria-containing booster dose was administered. Tetanus and diphtheria immunization schedule has been completed."
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SDengue3DosesWithPreVaccinationScreeningLogic.cql
+++ b/input/cql/IMMZD18SDengue3DosesWithPreVaccinationScreeningLogic.cql
@@ -215,3 +215,11 @@ define "Test Validation":
     when Patient.id = 'Dengue16.2' then "Third dengue dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHPV2DosesLogic.cql
+++ b/input/cql/IMMZD18SHPV2DosesLogic.cql
@@ -219,3 +219,11 @@ define "Test Validation":
     when Patient.id = 'HPV19.1' then "Third HPV dose from the primary series was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHPVSingleDoseLogic.cql
+++ b/input/cql/IMMZD18SHPVSingleDoseLogic.cql
@@ -222,3 +222,11 @@ define "Test Validation":
     when Patient.id = 'HPV39.1' then "Third HPV dose from the primary series was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisAInactivatedHAV1DoseLogic.cql
+++ b/input/cql/IMMZD18SHepatitisAInactivatedHAV1DoseLogic.cql
@@ -88,3 +88,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisA22.1' then "First hepatitis A dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisAInactivatedHAV2DosesLogic.cql
+++ b/input/cql/IMMZD18SHepatitisAInactivatedHAV2DosesLogic.cql
@@ -147,3 +147,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisA12.1' then "Second hepatitis A dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisALiveAttenuatedHAV1DoseLogic.cql
+++ b/input/cql/IMMZD18SHepatitisALiveAttenuatedHAV1DoseLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisA33.1' then "First hepatitis A dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisB3DosesLogic.cql
+++ b/input/cql/IMMZD18SHepatitisB3DosesLogic.cql
@@ -220,3 +220,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisB28.1' then "Third hepatitis B dose from the primary series was administered. The primary series has been completed for client whose weight at birth was less than 2000 g and was a premature infant"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisB4DosesLogic.cql
+++ b/input/cql/IMMZD18SHepatitisB4DosesLogic.cql
@@ -208,3 +208,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisB42.1' then not "Hepatitis B dose 3" and "Third hepatitis B dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisBBirthDoseLogic.cql
+++ b/input/cql/IMMZD18SHepatitisBBirthDoseLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisB10.1' then not "Hepatitis B birth dose" and "Hepatitis B birth dose was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHepatitisBDelayedStartLogic.cql
+++ b/input/cql/IMMZD18SHepatitisBDelayedStartLogic.cql
@@ -209,3 +209,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisB56.1' then not "Hepatitis B dose 3" and "Third hepatitis B dose was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHib2DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD18SHib2DosesWithBoosterDoseLogic.cql
@@ -218,3 +218,11 @@ define "Test Validation":
     when Patient.id = 'Hib50.1' then not "Haemophilus influenzae type b (Hib) dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHib3DosesLogic.cql
+++ b/input/cql/IMMZD18SHib3DosesLogic.cql
@@ -220,3 +220,11 @@ define "Test Validation":
     when Patient.id = 'Hib16.1' then not "Haemophilus influenzae type b (Hib) dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SHib3DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD18SHib3DosesWithBoosterDoseLogic.cql
@@ -280,3 +280,11 @@ define "Test Validation":
     when Patient.id = 'Hib34.1' then not "Haemophilus influenzae type b (Hib) dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SJEInactivatedVeroCellDerivedVaccineLogic.cql
+++ b/input/cql/IMMZD18SJEInactivatedVeroCellDerivedVaccineLogic.cql
@@ -146,3 +146,11 @@ define "Test Validation":
     when Patient.id = 'JE12.1' then "Second JE dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SJELiveAttenuatedVaccineLogic.cql
+++ b/input/cql/IMMZD18SJELiveAttenuatedVaccineLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'JE23.1' then "One JE dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SJELiveRecombinantVaccineLogic.cql
+++ b/input/cql/IMMZD18SJELiveRecombinantVaccineLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'JE34.1' then "One JE dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMalariaLogic.cql
+++ b/input/cql/IMMZD18SMalariaLogic.cql
@@ -267,3 +267,11 @@ define "Test Validation":
     when Patient.id = 'Malaria16.1' then "Fourth malaria dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeaslesLowTransmissionLogic.cql
+++ b/input/cql/IMMZD18SMeaslesLowTransmissionLogic.cql
@@ -147,3 +147,11 @@ define "Test Validation":
     when Patient.id = 'Measles28.1' then "MCV2 was administered. The primary series has been completed" and not "MCV2"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeaslesMCVDose0Logic.cql
+++ b/input/cql/IMMZD18SMeaslesMCVDose0Logic.cql
@@ -104,3 +104,11 @@ define "Test Validation":
     when Patient.id = 'Measles40.1' then "MCV0 was administered" 
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeaslesOngoingTransmissionLogic.cql
+++ b/input/cql/IMMZD18SMeaslesOngoingTransmissionLogic.cql
@@ -147,3 +147,11 @@ define "Test Validation":
     when Patient.id = 'Measles14.1' then "MCV2 was administered. The primary series has been completed." 
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeaslesSupplementaryDoseLogic.cql
+++ b/input/cql/IMMZD18SMeaslesSupplementaryDoseLogic.cql
@@ -87,3 +87,11 @@ define "Test Validation":
     when Patient.id = 'Measles50.1' then "MCV supplementary dose was administered" 
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalMenAConjugateVaccine1DoseLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalMenAConjugateVaccine1DoseLogic.cql
@@ -90,3 +90,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal10.1' then "One meningococcal dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalMenAConjugateVaccine2DosesLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalMenAConjugateVaccine2DosesLogic.cql
@@ -149,3 +149,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal22.1' then "Second meningococcal dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalMonovalentMenCConjugateVaccineLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalMonovalentMenCConjugateVaccineLogic.cql
@@ -210,3 +210,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal37.2' then "Meningococcal booster dose was administered for the client that started the series when client's age was less than or equal to 11 months. Immunization schedule has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalPolysaccharideVaccinesLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalPolysaccharideVaccinesLogic.cql
@@ -149,3 +149,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal72.3' then "Meningococcal booster dose was administered. The immunization schedule has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalQuadrivalentConjugateVaccines1DoseLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalQuadrivalentConjugateVaccines1DoseLogic.cql
@@ -88,3 +88,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal47.1' then "One meningococcal dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMeningococcalQuadrivalentConjugateVaccines2DosesLogic.cql
+++ b/input/cql/IMMZD18SMeningococcalQuadrivalentConjugateVaccines2DosesLogic.cql
@@ -151,3 +151,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal60.1' then "Second meningococcal dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SMumpsLogic.cql
+++ b/input/cql/IMMZD18SMumpsLogic.cql
@@ -153,3 +153,11 @@ define "Test Validation":
     when Patient.id = 'Mumps14.1' then "Second mumps dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPneumococcal2DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD18SPneumococcal2DosesWithBoosterDoseLogic.cql
@@ -297,3 +297,11 @@ define "Test Validation":
     when Patient.id = 'Pneumococcal25.1' then not "Pneumococcal dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPneumococcal3DosesLogic.cql
+++ b/input/cql/IMMZD18SPneumococcal3DosesLogic.cql
@@ -346,3 +346,11 @@ define "Test Validation":
     when Patient.id = 'Pneumococcal55.1' then not "Pneumococcal dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPolioBOPVPlusIPVLogic.cql
+++ b/input/cql/IMMZD18SPolioBOPVPlusIPVLogic.cql
@@ -340,3 +340,11 @@ define "Test Validation":
       and "Second IPV dose from the primary series was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPolioBirthDoseLogic.cql
+++ b/input/cql/IMMZD18SPolioBirthDoseLogic.cql
@@ -91,3 +91,11 @@ define "Test Validation":
     when Patient.id = 'Polio10.1' then not "bOPV birth dose (a zero dose)"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPolioIPVOnlyLogic.cql
+++ b/input/cql/IMMZD18SPolioIPVOnlyLogic.cql
@@ -262,3 +262,11 @@ define "Test Validation":
     when Patient.id = 'Polio80.2' then "Booster IPV dose was administered. Polio immunization schedule has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SPolioSequentialIPVbOPVLogic.cql
+++ b/input/cql/IMMZD18SPolioSequentialIPVbOPVLogic.cql
@@ -260,3 +260,11 @@ define "Test Validation":
     when Patient.id = 'Polio63.1' then "Second bOPV dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SRabiesLogic.cql
+++ b/input/cql/IMMZD18SRabiesLogic.cql
@@ -144,3 +144,11 @@ define "Test Validation":
     when Patient.id = 'Rabies11.1' then "Second rabies dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SRotavirusLogic.cql
+++ b/input/cql/IMMZD18SRotavirusLogic.cql
@@ -224,3 +224,11 @@ define "Test Validation":
     when Patient.id = 'Rotavirus18.1' then not "Rotavirus dose 1"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SRubellaHighIncidenceLogic.cql
+++ b/input/cql/IMMZD18SRubellaHighIncidenceLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'Rubella11.1' then "One rubella dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SRubellaLowIncidenceLogic.cql
+++ b/input/cql/IMMZD18SRubellaLowIncidenceLogic.cql
@@ -89,3 +89,11 @@ define "Test Validation":
     when Patient.id = 'Rubella22.1' then "One rubella dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SSeasonalinfluenzaSeasonalInfluenzaLogic.cql
+++ b/input/cql/IMMZD18SSeasonalinfluenzaSeasonalInfluenzaLogic.cql
@@ -212,3 +212,11 @@ define "Test Validation":
     when Patient.id = 'Seasonalinfluenza15.2' then "Seasonal influenza annual dose"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STBEEnceVirLogic.cql
+++ b/input/cql/IMMZD18STBEEnceVirLogic.cql
@@ -266,3 +266,11 @@ define "Test Validation":
     when Patient.id = 'TBE62.2' then "TBE EnceVir booster dose"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STBEEncepurLogic.cql
+++ b/input/cql/IMMZD18STBEEncepurLogic.cql
@@ -271,3 +271,11 @@ define "Test Validation":
     when Patient.id = 'TBE32.2' then "TBE booster dose was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STBEFSMEImmunLogic.cql
+++ b/input/cql/IMMZD18STBEFSMEImmunLogic.cql
@@ -271,3 +271,11 @@ define "Test Validation":
     when Patient.id = 'TBE16.2' then "TBE booster dose was administered"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STBETBEMoscowLogic.cql
+++ b/input/cql/IMMZD18STBETBEMoscowLogic.cql
@@ -266,3 +266,11 @@ define "Test Validation":
     when Patient.id = 'TBE47.2' then "TBE-Moscow booster dose(s)"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STyphoidTCVLogic.cql
+++ b/input/cql/IMMZD18STyphoidTCVLogic.cql
@@ -91,3 +91,11 @@ define "Test Validation":
     when Patient.id = 'Typhoid11.1' then "One typhoid dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STyphoidTy21aLogic.cql
+++ b/input/cql/IMMZD18STyphoidTy21aLogic.cql
@@ -150,3 +150,11 @@ define "Test Validation":
     when Patient.id = 'Typhoid35.4' then "Typhoid booster dose(s) repeat 3-doses series"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18STyphoidViPSLogic.cql
+++ b/input/cql/IMMZD18STyphoidViPSLogic.cql
@@ -146,3 +146,11 @@ define "Test Validation":
     when Patient.id = 'Typhoid22.2' then "Typhoid booster dose(s)"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SVaricella1DoseLogic.cql
+++ b/input/cql/IMMZD18SVaricella1DoseLogic.cql
@@ -91,3 +91,11 @@ define "Test Validation":
     when Patient.id = 'Varicella12.1' then "One varicella dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SVaricella2DosesLogic.cql
+++ b/input/cql/IMMZD18SVaricella2DosesLogic.cql
@@ -151,3 +151,11 @@ define "Test Validation":
     when Patient.id = 'Varicella27.1' then "Second varicella dose from the primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD18SYellowfeverYellowFeverLogic.cql
+++ b/input/cql/IMMZD18SYellowfeverYellowFeverLogic.cql
@@ -91,3 +91,11 @@ define "Test Validation":
     when Patient.id = 'Yellowfever10.1' then "One yellow fever dose from primary series was administered. The primary series has been completed"
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD2DTBCGLogic.cql
+++ b/input/cql/IMMZD2DTBCGLogic.cql
@@ -527,3 +527,14 @@ Check for any vaccines due and inform the caregiver of when to come back for the
 Check for any vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "BCG vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE1', display: 'BCG vaccines' } }, display: 'BCG vaccines' }

--- a/input/cql/IMMZD2DTCholeraWCRBSVaccine2DosesLogic.cql
+++ b/input/cql/IMMZD2DTCholeraWCRBSVaccine2DosesLogic.cql
@@ -163,3 +163,14 @@ Check for contraindications.'
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Cholera vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE2', display: 'Cholera vaccines' } }, display: 'Cholera vaccines' }

--- a/input/cql/IMMZD2DTCholeraWCRBSVaccine3DosesLogic.cql
+++ b/input/cql/IMMZD2DTCholeraWCRBSVaccine3DosesLogic.cql
@@ -244,3 +244,14 @@ Check for contraindications.'
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Cholera vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE2', display: 'Cholera vaccines' } }, display: 'Cholera vaccines' }

--- a/input/cql/IMMZD2DTCholeraWCVaccinesLogic.cql
+++ b/input/cql/IMMZD2DTCholeraWCVaccinesLogic.cql
@@ -256,3 +256,14 @@ Check for any vaccines due and inform the caregiver of when to come back for the
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Cholera vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE2', display: 'Cholera vaccines' } }, display: 'Cholera vaccines' }

--- a/input/cql/IMMZD2DTDTPDelayedOrInterruptedSeriesLogic.cql
+++ b/input/cql/IMMZD2DTDTPDelayedOrInterruptedSeriesLogic.cql
@@ -390,3 +390,16 @@ Pertussis immunization schedule is complete. Three DTP primary series doses and 
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Pertussis-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE12', display: 'Pertussis-containing vaccines' } }, display: 'Pertussis-containing vaccines' }
+define "DTP-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE24', display: 'DTP-containing vaccines' } }, display: 'DTP-containing vaccines' }
+define "Tetanus and diphtheria-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE28', display: 'Tetanus and diphtheria-containing vaccines' } }, display: 'Tetanus and diphtheria-containing vaccines' }

--- a/input/cql/IMMZD2DTDTPOnTimeStartLogic.cql
+++ b/input/cql/IMMZD2DTDTPOnTimeStartLogic.cql
@@ -467,3 +467,16 @@ Pertussis immunization schedule is complete. Three DTP primary series doses and 
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Pertussis-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE12', display: 'Pertussis-containing vaccines' } }, display: 'Pertussis-containing vaccines' }
+define "DTP-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE24', display: 'DTP-containing vaccines' } }, display: 'DTP-containing vaccines' }
+define "Tetanus and diphtheria-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE28', display: 'Tetanus and diphtheria-containing vaccines' } }, display: 'Tetanus and diphtheria-containing vaccines' }

--- a/input/cql/IMMZD2DTDTPPregnancyLogic.cql
+++ b/input/cql/IMMZD2DTDTPPregnancyLogic.cql
@@ -133,3 +133,11 @@ Check for any other vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD2DTDTPPregnancyStartingWith3DosesLogic.cql
+++ b/input/cql/IMMZD2DTDTPPregnancyStartingWith3DosesLogic.cql
@@ -167,3 +167,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Tetanus and diphtheria-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE28', display: 'Tetanus and diphtheria-containing vaccines' } }, display: 'Tetanus and diphtheria-containing vaccines' }

--- a/input/cql/IMMZD2DTDTPPregnancyStartingWith4DosesLogic.cql
+++ b/input/cql/IMMZD2DTDTPPregnancyStartingWith4DosesLogic.cql
@@ -123,3 +123,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Tetanus and diphtheria-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE28', display: 'Tetanus and diphtheria-containing vaccines' } }, display: 'Tetanus and diphtheria-containing vaccines' }

--- a/input/cql/IMMZD2DTDengue3DosesWithPreVaccinationScreeningLogic.cql
+++ b/input/cql/IMMZD2DTDengue3DosesWithPreVaccinationScreeningLogic.cql
@@ -212,3 +212,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Dengue vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE25', display: 'Dengue vaccines' } }, display: 'Dengue vaccines' }

--- a/input/cql/IMMZD2DTDengue3DosesWithoutPreVaccinationScreeningLogic.cql
+++ b/input/cql/IMMZD2DTDengue3DosesWithoutPreVaccinationScreeningLogic.cql
@@ -193,3 +193,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Dengue vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE25', display: 'Dengue vaccines' } }, display: 'Dengue vaccines' }

--- a/input/cql/IMMZD2DTHPV2DosesLogic.cql
+++ b/input/cql/IMMZD2DTHPV2DosesLogic.cql
@@ -274,3 +274,14 @@ Check for any other vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "HPV vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE7', display: 'HPV vaccines' } }, display: 'HPV vaccines' }

--- a/input/cql/IMMZD2DTHPVSingleDoseLogic.cql
+++ b/input/cql/IMMZD2DTHPVSingleDoseLogic.cql
@@ -284,3 +284,14 @@ Check for contraindications'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "HPV vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE7', display: 'HPV vaccines' } }, display: 'HPV vaccines' }

--- a/input/cql/IMMZD2DTHepatitisAInactivatedHAV1DoseLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisAInactivatedHAV1DoseLogic.cql
@@ -94,3 +94,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis A-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE5', display: 'Hepatitis A-containing vaccines' } }, display: 'Hepatitis A-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisAInactivatedHAV2DosesLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisAInactivatedHAV2DosesLogic.cql
@@ -144,3 +144,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis A-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE5', display: 'Hepatitis A-containing vaccines' } }, display: 'Hepatitis A-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisALiveAttenuatedHAV1DoseLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisALiveAttenuatedHAV1DoseLogic.cql
@@ -121,3 +121,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis A-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE5', display: 'Hepatitis A-containing vaccines' } }, display: 'Hepatitis A-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisB3DosesLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisB3DosesLogic.cql
@@ -234,3 +234,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis B-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE6', display: 'Hepatitis B-containing vaccines' } }, display: 'Hepatitis B-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisB4DosesLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisB4DosesLogic.cql
@@ -175,3 +175,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis B-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE6', display: 'Hepatitis B-containing vaccines' } }, display: 'Hepatitis B-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisBBirthDoseLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisBBirthDoseLogic.cql
@@ -85,3 +85,14 @@ define "Test Validation":
     when Patient.id = 'HepatitisB10.1' then "Client is not due for the hepatitis B birth dose" and "Guidance" = 'Hepatitis B birth dose was already administered. Check hepatitis B immunization schedule.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis B-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE6', display: 'Hepatitis B-containing vaccines' } }, display: 'Hepatitis B-containing vaccines' }

--- a/input/cql/IMMZD2DTHepatitisBDelayedStartLogic.cql
+++ b/input/cql/IMMZD2DTHepatitisBDelayedStartLogic.cql
@@ -182,3 +182,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis B-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE6', display: 'Hepatitis B-containing vaccines' } }, display: 'Hepatitis B-containing vaccines' }

--- a/input/cql/IMMZD2DTHib2DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD2DTHib2DosesWithBoosterDoseLogic.cql
@@ -236,3 +236,14 @@ Check for any vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hib-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE4', display: 'Hib-containing vaccines' } }, display: 'Hib-containing vaccines' }

--- a/input/cql/IMMZD2DTHib3DosesLogic.cql
+++ b/input/cql/IMMZD2DTHib3DosesLogic.cql
@@ -222,3 +222,14 @@ Check for any vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hib-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE4', display: 'Hib-containing vaccines' } }, display: 'Hib-containing vaccines' }

--- a/input/cql/IMMZD2DTHib3DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD2DTHib3DosesWithBoosterDoseLogic.cql
@@ -268,3 +268,14 @@ Check for any vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hib-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE4', display: 'Hib-containing vaccines' } }, display: 'Hib-containing vaccines' }

--- a/input/cql/IMMZD2DTJEInactivatedVeroCellDerivedVaccineLogic.cql
+++ b/input/cql/IMMZD2DTJEInactivatedVeroCellDerivedVaccineLogic.cql
@@ -145,3 +145,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "JE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE8', display: 'JE vaccines' } }, display: 'JE vaccines' }

--- a/input/cql/IMMZD2DTJELiveAttenuatedVaccineLogic.cql
+++ b/input/cql/IMMZD2DTJELiveAttenuatedVaccineLogic.cql
@@ -110,3 +110,14 @@ define "Test Validation":
     when Patient.id = 'JE23.1' then "JE immunization schedule is complete" and "Guidance" = 'JE immunization schedule is complete. One JE primary series dose was administered. Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "JE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE8', display: 'JE vaccines' } }, display: 'JE vaccines' }

--- a/input/cql/IMMZD2DTJELiveRecombinantVaccineLogic.cql
+++ b/input/cql/IMMZD2DTJELiveRecombinantVaccineLogic.cql
@@ -122,3 +122,14 @@ Check for any other vaccines due and inform the caregiver of when to come back f
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "JE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE8', display: 'JE vaccines' } }, display: 'JE vaccines' }

--- a/input/cql/IMMZD2DTMalariaLogic.cql
+++ b/input/cql/IMMZD2DTMalariaLogic.cql
@@ -204,3 +204,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Malaria vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE27', display: 'Malaria vaccines' } }, display: 'Malaria vaccines' }

--- a/input/cql/IMMZD2DTMeaslesLowTransmissionLogic.cql
+++ b/input/cql/IMMZD2DTMeaslesLowTransmissionLogic.cql
@@ -187,3 +187,14 @@ Check for any vaccines due and inform the caregiver of when to come back for MCV
 Check if a measles supplementary dose is appropriate for the client.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Measles-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE9', display: 'Measles-containing vaccines' } }, display: 'Measles-containing vaccines' }

--- a/input/cql/IMMZD2DTMeaslesMCVDose0Logic.cql
+++ b/input/cql/IMMZD2DTMeaslesMCVDose0Logic.cql
@@ -121,3 +121,11 @@ Check measles routine immunization schedule.'
 Check measles routine immunization schedule.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD2DTMeaslesOngoingTransmissionLogic.cql
+++ b/input/cql/IMMZD2DTMeaslesOngoingTransmissionLogic.cql
@@ -177,3 +177,14 @@ Check for any vaccines due and inform the caregiver of when to come back for MCV
 Check if a measles supplementary dose is appropriate for the client.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Measles-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE9', display: 'Measles-containing vaccines' } }, display: 'Measles-containing vaccines' }

--- a/input/cql/IMMZD2DTMeaslesSupplementaryDoseLogic.cql
+++ b/input/cql/IMMZD2DTMeaslesSupplementaryDoseLogic.cql
@@ -93,3 +93,11 @@ Check if one of the measles supplementary dose specific scenarios is applicable.
     when Patient.id = 'Measles50.1' then "Measles immunization schedule is complete" and "Guidance" = 'Measles immunization schedule is complete. Measles supplementary dose was administered.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD2DTMeningococcalMenAConjugateVaccine1DoseLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalMenAConjugateVaccine1DoseLogic.cql
@@ -94,3 +94,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMeningococcalMenAConjugateVaccine2DosesLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalMenAConjugateVaccine2DosesLogic.cql
@@ -144,3 +144,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMeningococcalMonovalentMenCConjugateVaccineLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalMonovalentMenCConjugateVaccineLogic.cql
@@ -205,3 +205,14 @@ Check for contraindications.'
 Check for any vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMeningococcalPolysaccharideVaccinesLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalPolysaccharideVaccinesLogic.cql
@@ -133,3 +133,14 @@ Check for any other vaccines due and inform the caregiver of when to come back f
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMeningococcalQuadrivalentConjugateVaccines1DoseLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalQuadrivalentConjugateVaccines1DoseLogic.cql
@@ -94,3 +94,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMeningococcalQuadrivalentConjugateVaccines2DosesLogic.cql
+++ b/input/cql/IMMZD2DTMeningococcalQuadrivalentConjugateVaccines2DosesLogic.cql
@@ -173,3 +173,14 @@ Check for any other vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Meningococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE10', display: 'Meningococcal vaccines' } }, display: 'Meningococcal vaccines' }

--- a/input/cql/IMMZD2DTMumpsLogic.cql
+++ b/input/cql/IMMZD2DTMumpsLogic.cql
@@ -178,3 +178,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Mumps-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE11', display: 'Mumps-containing vaccines' } }, display: 'Mumps-containing vaccines' }

--- a/input/cql/IMMZD2DTPneumococcal2DosesWithBoosterDoseLogic.cql
+++ b/input/cql/IMMZD2DTPneumococcal2DosesWithBoosterDoseLogic.cql
@@ -411,3 +411,14 @@ Check for any other vaccines due.'
     when Patient.id = 'Pneumococcal25.1' then "Clinical judgement is required. Create a clinical note" and "Guidance" = 'Members States should update this action according to the national immunization programme.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Pneumococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE13', display: 'Pneumococcal vaccines' } }, display: 'Pneumococcal vaccines' }

--- a/input/cql/IMMZD2DTPneumococcal3DosesLogic.cql
+++ b/input/cql/IMMZD2DTPneumococcal3DosesLogic.cql
@@ -509,3 +509,14 @@ Check for any other vaccines due.'
     when Patient.id = 'Pneumococcal55.1' then "Clinical judgement is required. Create a clinical note." and "Guidance" = 'Members States should update this action according to the national immunization programme'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Pneumococcal vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE13', display: 'Pneumococcal vaccines' } }, display: 'Pneumococcal vaccines' }

--- a/input/cql/IMMZD2DTPolioBOPVPlusIPVLogic.cql
+++ b/input/cql/IMMZD2DTPolioBOPVPlusIPVLogic.cql
@@ -608,3 +608,15 @@ Check for contraindications.'
 Check for any vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Oral polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE30', display: 'Oral polio vaccines' } }, display: 'Oral polio vaccines' }
+define "Inactivated polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE31', display: 'Inactivated polio vaccines' } }, display: 'Inactivated polio vaccines' }

--- a/input/cql/IMMZD2DTPolioBirthDoseLogic.cql
+++ b/input/cql/IMMZD2DTPolioBirthDoseLogic.cql
@@ -90,3 +90,14 @@ define "Test Validation":
     when Patient.id = 'Polio10.1' then "Client is not due for the bOPV birth dose Case 2" and "Guidance" = 'Poliovirus birth dose was already administered. Check poliovirus immunization schedule.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Oral polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE30', display: 'Oral polio vaccines' } }, display: 'Oral polio vaccines' }

--- a/input/cql/IMMZD2DTPolioIPVOnlyLogic.cql
+++ b/input/cql/IMMZD2DTPolioIPVOnlyLogic.cql
@@ -241,3 +241,14 @@ Check for contraindications.'
     when Patient.id = 'Polio80.2' then "Polio immunization schedule is complete Case 2" and "Guidance" = 'Polio immunization schedule is complete. Three poliovirus primary series doses and a booster dose were administered.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Inactivated polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE31', display: 'Inactivated polio vaccines' } }, display: 'Inactivated polio vaccines' }

--- a/input/cql/IMMZD2DTPolioSequentialIPVbOPVLogic.cql
+++ b/input/cql/IMMZD2DTPolioSequentialIPVbOPVLogic.cql
@@ -209,3 +209,15 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Oral polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE30', display: 'Oral polio vaccines' } }, display: 'Oral polio vaccines' }
+define "Inactivated polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE31', display: 'Inactivated polio vaccines' } }, display: 'Inactivated polio vaccines' }

--- a/input/cql/IMMZD2DTRabiesLogic.cql
+++ b/input/cql/IMMZD2DTRabiesLogic.cql
@@ -119,3 +119,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rabies vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE15', display: 'Rabies vaccines' } }, display: 'Rabies vaccines' }

--- a/input/cql/IMMZD2DTRotavirusLogic.cql
+++ b/input/cql/IMMZD2DTRotavirusLogic.cql
@@ -254,3 +254,14 @@ Check for contraindications.'
     when Patient.id = 'Rotavirus18.1' then "Client is not due for rotavirus vaccination if immunization schedule is not complete." and "Guidance" = 'Should not vaccinate client with rotavirus dose as client\'s age is more than 24 months. Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rotavirus vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE16', display: 'Rotavirus vaccines' } }, display: 'Rotavirus vaccines' }

--- a/input/cql/IMMZD2DTRubellaHighIncidenceLogic.cql
+++ b/input/cql/IMMZD2DTRubellaHighIncidenceLogic.cql
@@ -121,3 +121,14 @@ Check for any other vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rubella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE17', display: 'Rubella-containing vaccines' } }, display: 'Rubella-containing vaccines' }

--- a/input/cql/IMMZD2DTRubellaLowIncidenceLogic.cql
+++ b/input/cql/IMMZD2DTRubellaLowIncidenceLogic.cql
@@ -122,3 +122,14 @@ Check for any other vaccines due.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rubella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE17', display: 'Rubella-containing vaccines' } }, display: 'Rubella-containing vaccines' }

--- a/input/cql/IMMZD2DTSeasonalinfluenzaSeasonalInfluenzaLogic.cql
+++ b/input/cql/IMMZD2DTSeasonalinfluenzaSeasonalInfluenzaLogic.cql
@@ -224,3 +224,14 @@ Check for any other vaccines due and inform the caregiver of when to come back f
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Seasonal influenza vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE18', display: 'Seasonal influenza vaccines' } }, display: 'Seasonal influenza vaccines' }

--- a/input/cql/IMMZD2DTTBEEnceVirLogic.cql
+++ b/input/cql/IMMZD2DTTBEEnceVirLogic.cql
@@ -197,3 +197,14 @@ Check for contraindications.'
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "TBE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE20', display: 'TBE vaccines' } }, display: 'TBE vaccines' }

--- a/input/cql/IMMZD2DTTBEEncepurLogic.cql
+++ b/input/cql/IMMZD2DTTBEEncepurLogic.cql
@@ -220,3 +220,14 @@ Check for contraindications.'
 Check for any vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "TBE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE20', display: 'TBE vaccines' } }, display: 'TBE vaccines' }

--- a/input/cql/IMMZD2DTTBEFSMEImmunLogic.cql
+++ b/input/cql/IMMZD2DTTBEFSMEImmunLogic.cql
@@ -217,3 +217,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "TBE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE20', display: 'TBE vaccines' } }, display: 'TBE vaccines' }

--- a/input/cql/IMMZD2DTTBETBEMoscowLogic.cql
+++ b/input/cql/IMMZD2DTTBETBEMoscowLogic.cql
@@ -197,3 +197,14 @@ Check for contraindications.'
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "TBE vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE20', display: 'TBE vaccines' } }, display: 'TBE vaccines' }

--- a/input/cql/IMMZD2DTTyphoidTCVLogic.cql
+++ b/input/cql/IMMZD2DTTyphoidTCVLogic.cql
@@ -111,3 +111,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Typhoid vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE21', display: 'Typhoid vaccines' } }, display: 'Typhoid vaccines' }

--- a/input/cql/IMMZD2DTTyphoidTy21aLogic.cql
+++ b/input/cql/IMMZD2DTTyphoidTy21aLogic.cql
@@ -171,3 +171,14 @@ Check for contraindications.'
 Check for any other vaccines due and inform the caregiver or the client when the next dose should be administered'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Typhoid vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE21', display: 'Typhoid vaccines' } }, display: 'Typhoid vaccines' }

--- a/input/cql/IMMZD2DTTyphoidViPSLogic.cql
+++ b/input/cql/IMMZD2DTTyphoidViPSLogic.cql
@@ -116,3 +116,14 @@ Check for any other vaccines due and inform the caregiver of when to come back f
 Check for contraindications.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Typhoid vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE21', display: 'Typhoid vaccines' } }, display: 'Typhoid vaccines' }

--- a/input/cql/IMMZD2DTVaricella1DoseLogic.cql
+++ b/input/cql/IMMZD2DTVaricella1DoseLogic.cql
@@ -121,3 +121,14 @@ Check for contraindications.'
 Check for any vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Varicella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE22', display: 'Varicella-containing vaccines' } }, display: 'Varicella-containing vaccines' }

--- a/input/cql/IMMZD2DTVaricella2DosesLogic.cql
+++ b/input/cql/IMMZD2DTVaricella2DosesLogic.cql
@@ -157,3 +157,14 @@ define "Test Validation":
     when Patient.id = 'Varicella27.1' then "Varicella immunization schedule is complete" and "Guidance" = 'Varicella immunization schedule is complete. Two varicella primary series doses were administered. Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Varicella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE22', display: 'Varicella-containing vaccines' } }, display: 'Varicella-containing vaccines' }

--- a/input/cql/IMMZD2DTYellowfeverYellowFeverLogic.cql
+++ b/input/cql/IMMZD2DTYellowfeverYellowFeverLogic.cql
@@ -119,3 +119,14 @@ Check for contraindications.'
 Check for any other vaccines due.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Yellow fever vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE23', display: 'Yellow fever vaccines' } }, display: 'Yellow fever vaccines' }

--- a/input/cql/IMMZD5DTBCGContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTBCGContraindicationsLogic.cql
@@ -133,3 +133,14 @@ define "Test Validation":
     when Patient.id = 'BCG41.2' then "BCG vaccination could be contraindicated. Clinical judgement is required. Create a clinical note. Case 2" and "Guidance" = 'Do not vaccinate client with BCG if client is exposed to or receives immunosuppressive treatment'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "BCG vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE1', display: 'BCG vaccines' } }, display: 'BCG vaccines' }

--- a/input/cql/IMMZD5DTDTPContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTDTPContraindicationsLogic.cql
@@ -75,3 +75,14 @@ define "Test Validation":
     when Patient.id = 'DTP89.1' then "Tetanus vaccination is contraindicated" and "Guidance" = 'Do not vaccinate client with tetanus as tetanus vaccination is contraindicated for clients with severe acute illness'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Tetanus-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE19', display: 'Tetanus-containing vaccines' } }, display: 'Tetanus-containing vaccines' }

--- a/input/cql/IMMZD5DTDengueContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTDengueContraindicationsLogic.cql
@@ -170,3 +170,14 @@ define "Test Validation":
     when Patient.id = 'Dengue45.1' then "Dengue vaccination is contraindicated Case 7" and "Guidance" = 'Do not vaccinate client with dengue as dengue vaccination is contraindicated in individuals with symptomatic HIV.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Dengue vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE25', display: 'Dengue vaccines' } }, display: 'Dengue vaccines' }

--- a/input/cql/IMMZD5DTHPVContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTHPVContraindicationsLogic.cql
@@ -73,3 +73,14 @@ define "Test Validation":
     when Patient.id = 'HPV46.1' then "HPV vaccination could be contraindicated. Clinical judgement is required. Create a clinical note" and "Guidance" = 'Do not vaccinate client with HPV if client has history of a severe allergic reaction after a previous HPV vaccine dose, or to a component of the vaccine.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "HPV vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE7', display: 'HPV vaccines' } }, display: 'HPV vaccines' }

--- a/input/cql/IMMZD5DTHepatitisAContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTHepatitisAContraindicationsLogic.cql
@@ -97,3 +97,14 @@ define "Test Validation":
 Do not vaccinate client with live attenuated hepatitis A vaccination if client has severe allergy to components included in the live attenuated hepatitis A-containing vaccines.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Hepatitis A-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE5', display: 'Hepatitis A-containing vaccines' } }, display: 'Hepatitis A-containing vaccines' }

--- a/input/cql/IMMZD5DTHepatitisBContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTHepatitisBContraindicationsLogic.cql
@@ -57,3 +57,11 @@ define "Test Validation":
     when Patient.id = 'HepatitisB62.1' then "Hepatitis B vaccination could be contraindicated. Clinical judgement is required. Create a clinical note." and "Guidance" = 'Do not vaccinate client with hepatitis B if the client had a history of serious allergic reactions to any of the vaccine components. Allergy to yeast is considered a contraindication to immunization with yeast-produced hepatitis B-containing vaccine.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTHibContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTHibContraindicationsLogic.cql
@@ -57,3 +57,11 @@ define "Test Validation":
     when Patient.id = 'Hib56.1' then "Hib vaccination could be contraindicated. Clinical judgement is required. Create a clinical note." and "Guidance" = 'Do not vaccinate client with Hib conjugate vaccine if client has had allergic reaction or known allergies to any component of the vaccine.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTJEContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTJEContraindicationsLogic.cql
@@ -78,3 +78,11 @@ define "Test Validation":
     when Patient.id = 'JE41.1' then "Clinical judgement is required. Create a clinical note Case 2" and "Guidance" = 'The client is currently pregnant, consider risks of vaccination and make a judgement. Inactivated Vero cell-derived vaccines are preferred over live attenuated or live recombinant vaccines.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTMalariaContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTMalariaContraindicationsLogic.cql
@@ -57,3 +57,11 @@ define "Test Validation":
     when Patient.id = 'Malaria23.1' then "Malaria vaccination could be contraindicated. Clinical judgement is required. Create a clinical note" and "Guidance" = 'Do not vaccinate client with RTS,S/AS01 vaccine if client has severe hypersensitivity to any of the vaccine components.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTMeaslesContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTMeaslesContraindicationsLogic.cql
@@ -131,3 +131,14 @@ define "Test Validation":
     when Patient.id = 'Measles60.1' then "Clinical judgement required. Create a clinical note Case 2" and "Guidance" = 'Client has symptomatic HIV infection. Measles vaccination may be considered if the client is not severely immunosuppressed according to conventional definitions, consider risks of vaccination and make a clinical judgement.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Measles-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE9', display: 'Measles-containing vaccines' } }, display: 'Measles-containing vaccines' }

--- a/input/cql/IMMZD5DTMeningococcalContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTMeningococcalContraindicationsLogic.cql
@@ -57,3 +57,11 @@ define "Test Validation":
     when Patient.id = 'Meningococcal78.1' then "Meningococcal vaccination could be contraindicated. Clinical judgement is required. Create a clinical note" and "Guidance" = 'Do not vaccinate client with meningococcal if client has history of severe allergic reaction to any component of the meningococcal vaccine.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTMumpsContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTMumpsContraindicationsLogic.cql
@@ -106,3 +106,14 @@ define "Test Validation":
     when Patient.id = 'Mumps23.1' then "Mumps vaccination is contraindicated Case 3" and "Guidance" = 'Do not vaccinate client with mumps as mumps vaccination is contraindicated in immunosuppressed individuals.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Mumps-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE11', display: 'Mumps-containing vaccines' } }, display: 'Mumps-containing vaccines' }

--- a/input/cql/IMMZD5DTPneumococcalContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTPneumococcalContraindicationsLogic.cql
@@ -73,3 +73,11 @@ define "Test Validation":
     when Patient.id = 'Pneumococcal62.1' then "Pneumococcal vaccination could be contraindicated. Clinical judgement is required. Create a clinical note." and "Guidance" = 'Do not vaccinate client with pneumococcal if client has a history of severe allergic reactions to any component of the vaccine.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTPolioContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTPolioContraindicationsLogic.cql
@@ -106,3 +106,14 @@ Check if vaccination with IPV is appropriate for the client, consider risks of v
 Check if vaccination with IPV is appropriate for the client, consider risks of vaccination and make a clinical judgement.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Oral polio vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE30', display: 'Oral polio vaccines' } }, display: 'Oral polio vaccines' }

--- a/input/cql/IMMZD5DTRabiesContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTRabiesContraindicationsLogic.cql
@@ -57,3 +57,11 @@ define "Test Validation":
     when Patient.id = 'Rabies17.1' then "Clinical judgement is required. Create a clinical note" and "Guidance" = 'Check if the client has a history of severe hypersensitivity to any of the components or to excipients listed by the vaccine manufacturer. If so, provide an alternative rabies vaccine product for PreP.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTRotavirusContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTRotavirusContraindicationsLogic.cql
@@ -199,3 +199,14 @@ Check if the client has no known severe hypersensitivity to rotavirus vaccines c
     when Patient.id = 'Rotavirus34.1' then "Clinical judgement is required. Create a clinical note Case 6" and "Guidance" = 'Client has moderate to severe fever, consider risks of vaccination and make a judgement. Consider delaying rotavirus vaccination.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rotavirus vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE16', display: 'Rotavirus vaccines' } }, display: 'Rotavirus vaccines' }

--- a/input/cql/IMMZD5DTRubellaContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTRubellaContraindicationsLogic.cql
@@ -154,3 +154,14 @@ define "Test Validation":
     when Patient.id = 'Rubella35.1' then "Rubella vaccination is contraindicated Case 6" and "Guidance" = 'Do not vaccinate client with rubella as rubella vaccination is contraindicated for clients receiving or exposed to immunosuppressive therapy.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Rubella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE17', display: 'Rubella-containing vaccines' } }, display: 'Rubella-containing vaccines' }

--- a/input/cql/IMMZD5DTSeasonalInfluenzaContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTSeasonalInfluenzaContraindicationsLogic.cql
@@ -78,3 +78,11 @@ define "Test Validation":
     when Patient.id = 'Seasonalinfluenza22.1' then "Seasonal influenza vaccination could be contraindicated. Clinical judgement is required. Create a clinical note Case 2" and "Guidance" = 'Do not vaccinate client with seasonal influenza if client has had a severe allergic reaction (e.g. anaphylaxis) after a previous dose or to a vaccine component.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTTBEContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTTBEContraindicationsLogic.cql
@@ -78,3 +78,11 @@ define "Test Validation":
     when Patient.id = 'TBE70.1' then "Clinical judgement is required. Create a clinical note Case 2" and "Guidance" = 'Consider postponing the vaccination if the client has fever > 38.5°C or other signs of serious disease. Consider risks of vaccination and make a clinical judgement.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }

--- a/input/cql/IMMZD5DTTyphoidContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTTyphoidContraindicationsLogic.cql
@@ -111,3 +111,14 @@ define "Test Validation":
     when Patient.id = 'Typhoid44.2' then "Typhoid vaccination is contraindicated for Ty21a vaccine. Case 2" and "Guidance" = 'Do not vaccinate client with Ty21a vaccine as Ty21a vaccine is contraindicated for HIV-infected client who are not immunologically stable.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Typhoid vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE21', display: 'Typhoid vaccines' } }, display: 'Typhoid vaccines' }

--- a/input/cql/IMMZD5DTVaricellaContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTVaricellaContraindicationsLogic.cql
@@ -121,3 +121,14 @@ define "Test Validation":
     when Patient.id = 'Varicella38.1' then "Clinical judgement is required. Create clinical note Case 3" and "Guidance" = 'Client is receiving or has received medications that may be immunosuppressive, consider risks of vaccination and make a judgement.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Varicella-containing vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE22', display: 'Varicella-containing vaccines' } }, display: 'Varicella-containing vaccines' }

--- a/input/cql/IMMZD5DTYellowFeverContraindicationsLogic.cql
+++ b/input/cql/IMMZD5DTYellowFeverContraindicationsLogic.cql
@@ -153,3 +153,14 @@ define "Test Validation":
     when Patient.id = 'Yellowfever22.1' then "Clinical judgement is required. Create a clinical note Case 4" and "Guidance" = 'Conduct a risk–benefit assessment since yellow fever is a live vaccine and make a clinical judgement. Lactating women should be advised that the benefits of breastfeeding far outweigh alternatives.'
     else 'No test case set'
   end
+
+// @generated dynamicValue constants
+// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,
+// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.
+// See input/fsh/rulesets/rulesets-plandefinition.fsh.
+define "Draft Status": 'draft'
+define "Proposal Intent": 'proposal'
+define "Active Status": 'active'
+define "Alert Category Coding": Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }
+define "Routine Priority": Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }
+define "Yellow fever vaccines Medication": Concept { codes: { Code { system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', code: 'DE23', display: 'Yellow fever vaccines' } }, display: 'Yellow fever vaccines' }

--- a/input/fsh/rulesets/rulesets-plandefinition.fsh
+++ b/input/fsh/rulesets/rulesets-plandefinition.fsh
@@ -15,6 +15,15 @@ RuleSet: PlanDefMain( library, version )
   * type = #citation
   * citation = "WHO recommendations for routine immunization - summary tables (January 2025)"
 
+// Constant dynamicValues resolve via `text/cql-identifier` to named defines in
+// the PlanDefinition's primary library (same mechanism as `condition` and
+// `payload.contentString`). Inline `text/cql-expression` literals are compiled
+// CQL→ELM on every $apply invocation because each is wrapped in a fresh
+// anonymous library that the compiled-library cache cannot key on; identifier
+// references evaluate from the already-compiled primary library instead.
+// The defines are appended to each *Logic library by
+// `tools/add_dynamicvalue_defines.py`.
+
 RuleSet: PlanDefMRAction( title, description, rationale, condition, code, display )
 * action[+]
   * extension[+]
@@ -32,18 +41,18 @@ RuleSet: PlanDefMRAction( title, description, rationale, condition, code, displa
   * dynamicValue[+]
     * path = "status"
     * expression
-      * language = #text/cql-expression
-      * expression = "'draft'"
+      * language = #text/cql-identifier
+      * expression = "Draft Status"
   * dynamicValue[+]
     * path = "intent"
     * expression
-      * language = #text/cql-expression
-      * expression = "'proposal'"
+      * language = #text/cql-identifier
+      * expression = "Proposal Intent"
   * dynamicValue[+]
     * path = "medication"
     * expression
-      * language = #text/cql-expression
-      * expression = "Concept { codes: { Code { {code}, display: '{display}' } }, display: '{display}' }"
+      * language = #text/cql-identifier
+      * expression = "{display} Medication"
 
 RuleSet: PlanDefMRUpdate( title, description, condition, mrid, code, display )
 * action[+]
@@ -66,8 +75,8 @@ RuleSet: PlanDefMRUpdate( title, description, condition, mrid, code, display )
   * dynamicValue[+]
     * path = "medication"
     * expression
-      * language = #text/cql-expression
-      * expression = "Concept { codes: { Code { {code}, display: '{display}' } }, display: '{display}' }"
+      * language = #text/cql-identifier
+      * expression = "{display} Medication"
 
 RuleSet: PlanDefCommunicationRequestAction( title, description, condition, text )
 * action[+]
@@ -83,8 +92,8 @@ RuleSet: PlanDefCommunicationRequestAction( title, description, condition, text 
   * dynamicValue[+]
     * path = "status"
     * expression
-      * language = #text/cql-expression
-      * expression = "'active'"
+      * language = #text/cql-identifier
+      * expression = "Active Status"
   * dynamicValue[+]
     * path = "payload.contentString"
     * expression
@@ -106,11 +115,11 @@ RuleSet: PlanDefCommunicationRequestAction( title, description, condition, text 
     * path = "category.coding"
     * expression
       * description = "Category of communication"
-      * language = #text/cql-expression
-      * expression = "Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }"
+      * language = #text/cql-identifier
+      * expression = "Alert Category Coding"
   * dynamicValue[+]
     * path = "priority"
     * expression
       * description = "Alert priority"
-      * language = #text/cql-expression
-      * expression = "Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }"
+      * language = #text/cql-identifier
+      * expression = "Routine Priority"

--- a/tools/add_dynamicvalue_defines.py
+++ b/tools/add_dynamicvalue_defines.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Add cql-identifier defines for PlanDefinition dynamicValue constants to each
+*Logic.cql primary library.
+
+`rulesets-plandefinition.fsh` resolves constant `dynamicValue`s
+(`status`, `intent`, `medication`, `category.coding`, `priority`) via
+`text/cql-identifier`, which requires the named define to exist in each
+PlanDefinition's primary library. This script appends those defines.
+
+It reads `fsh-generated/resources/PlanDefinition-*.json` to discover, per
+primary library, which defines that library's PlanDefinition(s) reference,
+then appends a `// @generated dynamicValue constants` block to the
+corresponding `input/cql/{lib}.cql`.
+
+Usage (from the repo root, after `sushi build`):
+
+    python3 tools/add_dynamicvalue_defines.py .
+
+Idempotent: skips files that already contain the marker. Re-run after
+adding new PlanDefinitions; the script picks up new primary libraries and
+new medication codes from the rebuilt `fsh-generated/` output.
+"""
+import glob
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+REPO = sys.argv[1] if len(sys.argv) > 1 else "."
+MARKER = "// @generated dynamicValue constants"
+
+
+def immz_z_codes():
+    """display → code, parsed from the canonical IMMZ.Z code system."""
+    out = {}
+    for line in open(f"{REPO}/input/fsh/codesystems/IMMZ.Z.fsh"):
+        m = re.match(r'\* #(\S+)\s+"([^"]+)"', line)
+        if m:
+            out[m.group(2)] = m.group(1)
+    return out
+
+
+def medication_display(dv):
+    """Extract the IMMZ.Z display string from a `medication` dynamicValue,
+    whether it's still the inline `text/cql-expression` Concept constructor or
+    already the `text/cql-identifier` form."""
+    expr = dv["expression"]["expression"]
+    m = re.search(r"display:\s*'([^']+)'", expr)
+    if m:
+        return m.group(1)
+    if expr.endswith(" Medication"):
+        return expr[: -len(" Medication")]
+    return None
+
+
+def load_requirements():
+    """Map library name → {needs_mr, needs_cr, medications: set[(code, display)]}."""
+    by_display = immz_z_codes()
+    reqs = defaultdict(lambda: {"needs_mr": False, "needs_cr": False, "medications": set()})
+    for f in glob.glob(f"{REPO}/fsh-generated/resources/PlanDefinition-IMMZD*.json"):
+        pd = json.load(open(f))
+        libs = pd.get("library", [])
+        if not libs:
+            continue
+        lib = libs[0].rsplit("/", 1)[-1]
+        for a in pd.get("action", []):
+            dvs = a.get("dynamicValue", [])
+            paths = {dv.get("path") for dv in dvs}
+            if "medication" in paths:
+                reqs[lib]["needs_mr"] = True
+                for dv in dvs:
+                    if dv.get("path") != "medication":
+                        continue
+                    display = medication_display(dv)
+                    if display and display in by_display:
+                        reqs[lib]["medications"].add((by_display[display], display))
+            if "category.coding" in paths or "priority" in paths:
+                reqs[lib]["needs_cr"] = True
+            if any(
+                dv.get("path") == "status"
+                and dv["expression"]["expression"] in ("'active'", "Active Status")
+                for dv in dvs
+            ):
+                reqs[lib]["needs_cr"] = True
+            if any(
+                dv.get("path") == "status"
+                and dv["expression"]["expression"] in ("'draft'", "Draft Status")
+                for dv in dvs
+            ):
+                reqs[lib]["needs_mr"] = True
+    return reqs
+
+
+def block_for(req):
+    lines = [
+        "",
+        MARKER,
+        "// Resolved via text/cql-identifier from PlanDefinition.action.dynamicValue,",
+        "// avoiding per-$apply CQL→ELM compilation of inline text/cql-expression literals.",
+        "// See input/fsh/rulesets/rulesets-plandefinition.fsh.",
+    ]
+    if req["needs_mr"]:
+        lines.append('define "Draft Status": \'draft\'')
+        lines.append('define "Proposal Intent": \'proposal\'')
+    if req["needs_cr"]:
+        lines.append('define "Active Status": \'active\'')
+        lines.append(
+            'define "Alert Category Coding": '
+            "Code { system: 'http://terminology.hl7.org/CodeSystem/communication-category', code: 'alert' }"
+        )
+        lines.append(
+            'define "Routine Priority": '
+            "Code { system: 'http://hl7.org/fhir/request-priority', code: 'routine' }"
+        )
+    for code, display in sorted(req["medications"]):
+        lines.append(
+            f'define "{display} Medication": '
+            f"Concept {{ codes: {{ Code {{ system: 'http://smart.who.int/immunizations/CodeSystem/IMMZ.Z', "
+            f"code: '{code}', display: '{display}' }} }}, display: '{display}' }}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    reqs = load_requirements()
+    print(f"Libraries needing defines: {len(reqs)}")
+    written, skipped, missing = 0, 0, 0
+    for lib, req in sorted(reqs.items()):
+        path = f"{REPO}/input/cql/{lib}.cql"
+        if not os.path.exists(path):
+            print(f"  MISSING: {path}")
+            missing += 1
+            continue
+        with open(path) as f:
+            content = f.read()
+        if MARKER in content:
+            skipped += 1
+            continue
+        with open(path, "a") as f:
+            f.write(block_for(req))
+        written += 1
+    print(f"Written: {written}, skipped (already done): {skipped}, missing: {missing}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We found a 45–130× speedup for PlanDefinition/$apply against this IG on HAPI's clinical-reasoning module. 
 
On stock HAPI 8.8.0, $apply on any IMMZ PlanDefinition currently takes ~5–11 seconds; with this change it's ~40 ms. We came across this work when building an MCP, where we need a more interactive latency. 

It looks like the six constant dynamicValue expressions in the shared PlanDef rulesets (_status, intent, medication,
  category.coding, priority_) use inline text/cql-expression literals. HAPI wraps each inline expression in a fresh library on every call, which the compiled-library cache can't key on. So it recompiles CQL→ELM from scratch, which is taking ~1 s per expression, per call. But the actual primary-library evaluation is ~5 ms.

Fix: reference those same constants via text/cql-identifier instead, pointing at named define statements in each PlanDefinition's primary *Logic library — the same mechanism condition and payload.contentString already use. The defines evaluate from the already-compiled library; no per-call compile.

**Output is byte-identical.** Same dynamicValue paths, same values; only expression.language changes. 

Note that the real change is one file (input/fsh/rulesets/rulesets-plandefinition.fsh, ~14 lines). But each of the 138
  *Logic.cql libraries needs the named defines appended so the identifier references resolve. Thats why there are so many file changes in this PR.
  
  tools/add_dynamicvalue_defines.py generates these changes — reads fsh-generated/ after sushi build, appends the // @generated block per library. Commit c5d5659 is just that generator's output .

The generator is Python, placed under tools/ alongside the existing Node and Perl scripts. 

Happy to discuss if there is a reason the inline form is preferred.