### PR TITLE
Add `expected:` blocks to Measles Low Transmission test YAML

### DIFF
--- a/input/tests/plandefinition/IMMZD2DTMeaslesLowTransmissionLogic/IMMZD2DTMeaslesLowTransmissionLogic.yaml
+++ b/input/tests/plandefinition/IMMZD2DTMeaslesLowTransmissionLogic/IMMZD2DTMeaslesLowTransmissionLogic.yaml
@@ -8,6 +8,18 @@ birth: -1d
 patient:
   fhir:
     gender: female
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R1
+  defines:
+    "Client is not due for MCV1 Case 1": true
+    "Client is not due for MCV1": true
+    "Client is due for MCV1": false
+    "Client is not due for MCV2": false
+    "Client is due for MCV2": false
+    "Measles primary series is complete": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should not vaccinate client with MCV1 as client's age is less than 12 months.\nCheck for any vaccines due and inform the caregiver of when to come back for MCV1."
 ---
 #No measles primary series doses were administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 0
@@ -22,6 +34,17 @@ birth: -12m
 patient:
   fhir:
     gender: female
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R2
+  defines:
+    "Client is due for MCV1": true
+    "Client is not due for MCV1": false
+    "Client is not due for MCV1 Case 1": false
+    "Client is not due for MCV1 Case 2": false
+    "Measles primary series is complete": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should vaccinate client with MCV1 as no measles doses were administered, client is within appropriate age range and no live vaccine was administered in the past 4 weeks.\nCheck for contraindications."
 ---
 #No measles primary series doses were administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 0
@@ -45,6 +68,15 @@ immunization:
     fhir:
       expirationDate: 1y
       occurrenceDateTime: -2w
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R3
+  defines:
+    "Client is not due for MCV1 Case 2": true
+    "Client is not due for MCV1": true
+    "Client is due for MCV1": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should not vaccinate client with MCV1 as live vaccine was administered in the past 4 weeks.\nCheck for any vaccines due and inform the caregiver of when to come back for MCV1."
 ---
 #MCV1 was administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 1
@@ -70,6 +102,15 @@ immunization:
         - doseNumberString: "1"
           seriesDosesString: "2"
           series: Primary series
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R4
+  defines:
+    "Client is not due for MCV2 Case 1": true
+    "Client is not due for MCV2": true
+    "Client is due for MCV2": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should not vaccinate client with MCV2 as client's age is less than 15 months.\nCheck for any vaccines due and inform the caregiver of when to come back for MCV2."
 ---
 #MCV1 was administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 1
@@ -105,6 +146,17 @@ immunization:
         - doseNumberString: "1"
           seriesDosesString: "2"
           series: Primary series
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R5
+  defines:
+    "Client is due for MCV2": true
+    "Client is not due for MCV2": false
+    "Client is not due for MCV2 Case 1": false
+    "Client is not due for MCV2 Case 2": false
+    "Measles primary series is complete": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should vaccinate client with MCV2 as client is within appropriate age range and no live vaccine administered in the past 4 weeks.\nCheck for contraindications."
 ---
 #MCV1 was administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 1
@@ -140,6 +192,15 @@ immunization:
         - doseNumberString: "1"
           seriesDosesString: "2"
           series: Primary series
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R6
+  defines:
+    "Client is not due for MCV2 Case 2": true
+    "Client is not due for MCV2": true
+    "Client is due for MCV2": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Should not vaccinate client with MCV2 as live vaccine was administered in the past 4 weeks.\nCheck for any vaccines due and inform the caregiver of when to come back for MCV2."
 ---
 #MCV2 was administered
 #   Count of vaccines administered (where "Vaccine type" = "Measles-containing vaccines" and "Type of dose" = "Primary series") = 2
@@ -175,3 +236,14 @@ immunization:
         - doseNumberString: "2"
           seriesDosesString: "2"
           series: Primary series
+expected:
+  row: IMMZ.D2.DT.Measles.LowTransmission.R7
+  defines:
+    "Measles primary series is complete": true
+    "Client is due for MCV1": false
+    "Client is due for MCV2": false
+    "Client is not due for MCV1": false
+    "Client is not due for MCV2": false
+    "Has Guidance": true
+    "Guidance":
+      equals: "Measles primary series is complete. Two measles primary series doses were administered.\nCheck if a measles supplementary dose is appropriate for the client."


### PR DESCRIPTION
## Summary

- Adds an `expected:` block to each of the seven existing patient documents in `input/tests/plandefinition/IMMZD2DTMeaslesLowTransmissionLogic/IMMZD2DTMeaslesLowTransmissionLogic.yaml`, encoding the expected boolean and guidance-string outputs of the Logic library per patient.
- Zero behaviour change to the IG Publisher build, `makeExample.js`, or the Karate `.feature` generation — purely additive YAML keys.
- Concrete companion to RFC issue #136.

## Schema

Blocks follow the convention proposed in #136:

```yaml
expected:
  row: IMMZ.D2.DT.Measles.LowTransmission.R1
  defines:
    "Client is not due for MCV1 Case 1": true
    "Client is not due for MCV1": true
    "Guidance":
      equals: "Should not vaccinate client with MCV1 as client's age is less than 12 months.\nCheck for any vaccines due and inform the caregiver of when to come back for MCV1."
```

Identifiers correspond to the published CQL `define "<name>":` declarations in `input/cql/IMMZD2DTMeaslesLowTransmissionLogic.cql`.

## Provenance of the expected values

Each block was derived from existing artefacts already in this repository:

- the `### …` natural-language outcome lines already present at the top of each patient document, and
- the `Test Validation` case-expression in `input/cql/IMMZD2DTMeaslesLowTransmissionLogic.cql`.

The blocks were independently verified by running the published Logic library against the existing patient bundles using [cqframework/cql-execution](https://github.com/cqframework/cql-execution) at submodule HEAD (b16245f71); all 7 cases produce values that match the encoded `expected:` blocks.

## Compatibility

- `tools/node/makeExample.js` accesses YAML keys by name (`id`, `birth`, `patient`, `immunization`, `contraindication`, `medicationrequest`) and ignores others.
- `tools/node/processDAK.js --existing` re-emits arbitrary parsed keys, so the block survives regeneration from the L2 Excel source.
- No change to the IG Publisher build, `qa.html`, or `input/testing/features/plandefinition/<X>/<X>.feature`.

## Test plan

- [ ] WHO maintainer review of the schema (defer to RFC #136 for the cross-cutting convention discussion).
- [ ] Sanity-check by running `tools/node/makeExample.js` against the patched YAML; per-resource JSON output should be identical to the unpatched run.
- [ ] Optional: run the patched YAML through the IG Publisher locally and confirm `qa.html` is unchanged.